### PR TITLE
bump node version to 20.x

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ runs:
     - name: Set up Node
       uses: actions/setup-node@v3
       with:
-        node-version: 18.x
+        node-version: 20.x
     - run: |
         npm install -g @openfn/cli
         


### PR DESCRIPTION
**Description**
Currently GitHub Sync is broken because the latest cli version requires `node: '20 || >=22'`. This PR updates the node version to `20.x`.

[See failed sync here](https://github.com/OpenFn/msf-lime-mosul/actions/runs/16681451442/job/47220856586)
